### PR TITLE
Provide headers to parse rate limit responses on streaming requests

### DIFF
--- a/lib/twitter/streaming/response.rb
+++ b/lib/twitter/streaming/response.rb
@@ -19,9 +19,12 @@ module Twitter
         @parser << data
       end
 
-      def on_headers_complete(_headers)
+      def on_headers_complete(headers)
         error = Twitter::Error::ERRORS[@parser.status_code]
-        raise error if error
+        if error
+          error = error.new('', headers)
+          raise error
+        end
       end
 
       def on_body(data)


### PR DESCRIPTION
Sometimes we hit the twitter rate limit, and then retry every 60 seconds, which keeps us perpetually over the rate limit. The Twitter API provides headers with rate limit backoff information, but the gem doesn't pass the details to the client. Let's pass that through on the exception so we can take advantage of it.