### PR TITLE
Make rate limiting case insensitive to headers

### DIFF
--- a/lib/twitter/rate_limit.rb
+++ b/lib/twitter/rate_limit.rb
@@ -6,21 +6,21 @@ module Twitter
 
     # @return [Integer]
     def limit
-      limit = @attrs['x-rate-limit-limit']
+      limit = attrs['x-rate-limit-limit']
       limit&.to_i
     end
     memoize :limit
 
     # @return [Integer]
     def remaining
-      remaining = @attrs['x-rate-limit-remaining']
+      remaining = attrs['x-rate-limit-remaining']
       remaining&.to_i
     end
     memoize :remaining
 
     # @return [Time]
     def reset_at
-      reset = @attrs['x-rate-limit-reset']
+      reset = attrs['x-rate-limit-reset']
       Time.at(reset.to_i).utc if reset
     end
     memoize :reset_at
@@ -30,5 +30,11 @@ module Twitter
       [(reset_at - Time.now).ceil, 0].max if reset_at
     end
     alias retry_after reset_in
+
+  private
+
+    def attrs
+      @attrs.collect { |k, v| [k.downcase, v] }.to_h
+    end
   end
 end

--- a/spec/twitter/rate_limit_spec.rb
+++ b/spec/twitter/rate_limit_spec.rb
@@ -7,6 +7,11 @@ describe Twitter::RateLimit do
       expect(rate_limit.limit).to be_an Integer
       expect(rate_limit.limit).to eq(150)
     end
+    it 'is insensitive to header case' do
+      rate_limit = Twitter::RateLimit.new('X-Rate-Limit-Limit' => '150')
+      expect(rate_limit.limit).to be_an Integer
+      expect(rate_limit.limit).to eq(150)
+    end
     it 'returns nil when x-rate-limit-limit header is not set' do
       rate_limit = Twitter::RateLimit.new
       expect(rate_limit.limit).to be_nil
@@ -19,6 +24,11 @@ describe Twitter::RateLimit do
       expect(rate_limit.remaining).to be_an Integer
       expect(rate_limit.remaining).to eq(149)
     end
+    it 'is insensitive to header case' do
+      rate_limit = Twitter::RateLimit.new('X-Rate-Limit-Remaining' => '149')
+      expect(rate_limit.remaining).to be_an Integer
+      expect(rate_limit.remaining).to eq(149)
+    end
     it 'returns nil when x-rate-limit-remaining header is not set' do
       rate_limit = Twitter::RateLimit.new
       expect(rate_limit.remaining).to be_nil
@@ -28,6 +38,12 @@ describe Twitter::RateLimit do
   describe '#reset_at' do
     it 'returns a Time when x-rate-limit-reset header is set' do
       rate_limit = Twitter::RateLimit.new('x-rate-limit-reset' => '1339019097')
+      expect(rate_limit.reset_at).to be_a Time
+      expect(rate_limit.reset_at).to be_utc
+      expect(rate_limit.reset_at).to eq(Time.at(1_339_019_097))
+    end
+    it 'is insensitive to header case' do
+      rate_limit = Twitter::RateLimit.new('X-Rate-Limit-Reset' => '1339019097')
       expect(rate_limit.reset_at).to be_a Time
       expect(rate_limit.reset_at).to be_utc
       expect(rate_limit.reset_at).to eq(Time.at(1_339_019_097))
@@ -47,6 +63,11 @@ describe Twitter::RateLimit do
     end
     it 'returns an Integer when x-rate-limit-reset header is set' do
       rate_limit = Twitter::RateLimit.new('x-rate-limit-reset' => '1339019097')
+      expect(rate_limit.reset_in).to be_an Integer
+      expect(rate_limit.reset_in).to eq(15_777)
+    end
+    it 'is insensitive to header case' do
+      rate_limit = Twitter::RateLimit.new('X-Rate-Limit-Reset' => '1339019097')
       expect(rate_limit.reset_in).to be_an Integer
       expect(rate_limit.reset_in).to eq(15_777)
     end

--- a/spec/twitter/streaming/response_spec.rb
+++ b/spec/twitter/streaming/response_spec.rb
@@ -30,5 +30,18 @@ describe Twitter::Streaming::Response do
         expect(error.rate_limit.reset_in).to eq(reset_delay)
       end
     end
+
+    it 'is case-insensitive to headers' do
+      reset_delay = 300
+      reset_time = Time.at((Time.now.utc + reset_delay).to_i)
+      expect do
+        subject << "HTTP/1.1 420 NOK\r\nX-Rate-Limit-Limit: 150\r\nX-Rate-Limit-Remaining: 0\r\nX-Rate-Limit-Reset: #{reset_time.to_i}\r\n\r\n"
+      end.to raise_error(Twitter::Error::TooManyRequests) do |error|
+        expect(error.rate_limit.limit).to eq(150)
+        expect(error.rate_limit.remaining).to eq(0)
+        expect(error.rate_limit.reset_at).to eq(reset_time)
+        expect(error.rate_limit.reset_in).to eq(reset_delay)
+      end
+    end
   end
 end


### PR DESCRIPTION
The previous fix (#1) hasn't improved the rate limiting behaviour in practice. There have been some reports that twitter is inconsistent in providing these headers, so I'm not completely sure we can rely on them. Before we give up on them, we can close one possible issue by accessing the headers in a case-insensitive way.