### PR TITLE
Add non-blocking streaming support

### DIFF
--- a/lib/twitter/streaming/connection.rb
+++ b/lib/twitter/streaming/connection.rb
@@ -22,6 +22,16 @@ module Twitter
           response << body
         end
       end
+
+      def connected?
+        # Connection is established and broken within #stream, so we consider it closed anywhere else.
+        # For comparison, see NonblockingConnection.
+        false
+      end
+
+      def close
+        # No-op, as we only have a connection within #stream
+      end
     end
   end
 end

--- a/lib/twitter/streaming/nonblocking_connection.rb
+++ b/lib/twitter/streaming/nonblocking_connection.rb
@@ -1,0 +1,56 @@
+require 'http/parser'
+require 'openssl'
+require 'resolv'
+
+module Twitter
+  module Streaming
+    class NonblockingConnection
+      def initialize(opts = {})
+        @stream_connected = false
+        @tcp_socket_class = opts.fetch(:tcp_socket_class) { TCPSocket }
+        @ssl_socket_class = opts.fetch(:ssl_socket_class) { OpenSSL::SSL::SSLSocket }
+        @timeout = opts.fetch(:timeout, 60)
+      end
+      attr_reader :tcp_socket_class, :ssl_socket_class
+
+      def stream(request, response)
+        start_stream(request) unless @stream_connected
+        start_time = Time.now
+
+        begin
+          while body = @ssl_client.read_nonblock(1024) # rubocop:disable AssignmentInCondition
+            response << body
+          end
+        rescue IO::WaitReadable
+          # Wait for the socket to become readable (up to 1 second)
+          IO.select([@ssl_client], [], [], 1)
+
+          retry unless @timeout && Time.now > start_time + @timeout
+        end
+      end
+
+      def connected?
+        @stream_connected
+      end
+
+      def close
+        @ssl_client.sysclose
+        @stream_connected = false
+      end
+
+    private
+
+      def start_stream(request)
+        client_context = OpenSSL::SSL::SSLContext.new
+        client         = @tcp_socket_class.new(Resolv.getaddress(request.socket_host), request.socket_port)
+        @ssl_client     = @ssl_socket_class.new(client, client_context)
+        @ssl_client.sync_close = true
+
+        @ssl_client.connect
+        request.stream(@ssl_client)
+
+        @stream_connected = true
+      end
+    end
+  end
+end

--- a/lib/twitter/streaming/nonblocking_connection.rb
+++ b/lib/twitter/streaming/nonblocking_connection.rb
@@ -43,7 +43,7 @@ module Twitter
       def start_stream(request)
         client_context = OpenSSL::SSL::SSLContext.new
         client         = @tcp_socket_class.new(Resolv.getaddress(request.socket_host), request.socket_port)
-        @ssl_client     = @ssl_socket_class.new(client, client_context)
+        @ssl_client    = @ssl_socket_class.new(client, client_context)
         @ssl_client.sync_close = true
 
         @ssl_client.connect

--- a/spec/twitter/streaming/connection_spec.rb
+++ b/spec/twitter/streaming/connection_spec.rb
@@ -25,4 +25,20 @@ describe Twitter::Streaming::Connection do
       end
     end
   end
+
+  describe 'connected?' do
+    subject(:connection) { Twitter::Streaming::Connection.new }
+
+    it 'returns false' do
+      expect(connection.connected?).to be(false)
+    end
+  end
+
+  describe "close" do
+    subject(:connection) { Twitter::Streaming::Connection.new }
+
+    it "performs a no-op" do
+      expect(connection.close).to be_nil
+    end
+  end
 end

--- a/spec/twitter/streaming/nonblocking_connection_spec.rb
+++ b/spec/twitter/streaming/nonblocking_connection_spec.rb
@@ -1,0 +1,37 @@
+require 'helper'
+require 'twitter/streaming/nonblocking_connection'
+
+describe Twitter::Streaming::NonblockingConnection do
+  describe 'initialize' do
+    context 'no options provided' do
+      subject(:connection) { Twitter::Streaming::NonblockingConnection.new }
+
+      it 'sets the default socket classes' do
+        expect(connection.tcp_socket_class).to eq TCPSocket
+        expect(connection.ssl_socket_class).to eq OpenSSL::SSL::SSLSocket
+      end
+    end
+
+    context 'custom socket classes provided in opts' do
+      class DummyTCPSocket; end
+      class DummySSLSocket; end
+
+      subject(:connection) do
+        Twitter::Streaming::NonblockingConnection.new(tcp_socket_class: DummyTCPSocket, ssl_socket_class: DummySSLSocket)
+      end
+
+      it 'sets the default socket classes' do
+        expect(connection.tcp_socket_class).to eq DummyTCPSocket
+        expect(connection.ssl_socket_class).to eq DummySSLSocket
+      end
+    end
+
+    describe 'connected?' do
+      subject(:connection) { Twitter::Streaming::Connection.new }
+
+      it 'is initialised to false' do
+        expect(connection.connected?).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've seen a lot of unreliability with tc-social over the last few months, in particular with the tweet streaming service. Our worker opens streaming connections to the Twitter API and writes tweets to the eventlog and now also PubSub. However, we were seeing this service rate limited by Twitter, and once it occurred it seemed that rate limiting persisted until our worker was restarted.

We now believe this was happening because of how we manage our streaming worker. We run this worker in a thread, and kill and restart that thread every hour to provide some buffer against the unreliability of long-running TCP connections. However, this restart was performed via `Thread#kill`, which doesn't close open TCP connections. As a result, a new open connection was made to Twitter every hour, eventually hitting the limit of 50 connections, after which we would be rate limited.

Address this by implementing non-blocking streaming support on the Twitter client. With that support we'll be able to remove the thread entirely and manage our connection to Twitter directly.

See also: https://github.com/conversation/tc-social/pull/205