### PR TITLE
Use CGI.escape instead of URI.encode (removed in Ruby 3)

### DIFF
--- a/lib/twitter/streaming/client.rb
+++ b/lib/twitter/streaming/client.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 require 'http/request'
 require 'twitter/arguments'
 require 'twitter/client'
@@ -132,7 +133,7 @@ module Twitter
 
       def to_url_params(params)
         params.collect do |param, value|
-          [param, URI.encode(value)].join('=')
+          [param, CGI.escape(value)].join('=')
         end.sort.join('&')
       end
 


### PR DESCRIPTION
Ruby 3 removes `URI.encode`. We'd like to upgrade Ruby on tc-social, so switch to using the supported API.
